### PR TITLE
feat(translate-selection): improve controls and popup stability

### DIFF
--- a/src/common/components/view-popup/selection-popup.js
+++ b/src/common/components/view-popup/selection-popup.js
@@ -29,28 +29,30 @@ function SelectionPopup(props) {
 			uniqueRef={{}}
 			padding={20}
 		>
-			<div className="colors" data-tabstop={1}>
-				{ANNOTATION_COLORS.map((color, index) => (<button
-					key={index}
-					tabIndex={-1}
-					className="toolbar-button color-button"
-					title={l10n.getString(color[0])}
-					onClick={() => handleColorPick(color[1])}
-				><IconColor16 color={color[1]}/></button>))}
-			</div>
-			<div className="tool-toggle" data-tabstop={1}>
-				<button
-					tabIndex={-1}
-					className={cx('highlight', { active: props.textSelectionAnnotationMode === 'highlight' })}
-					title={l10n.getString('reader-highlight-text')}
-					onClick={() => props.onChangeTextSelectionAnnotationMode('highlight')}
-				><IconHighlight/></button>
-				<button
-					tabIndex={-1}
-					className={cx('underline', { active: props.textSelectionAnnotationMode === 'underline' })}
-					title={l10n.getString('reader-underline-text')}
-					onClick={() => props.onChangeTextSelectionAnnotationMode('underline')}
-				><IconUnderline/></button>
+			<div className="selection-popup-row">
+				<div className="colors" data-tabstop={1}>
+					{ANNOTATION_COLORS.map((color, index) => (<button
+						key={index}
+						tabIndex={-1}
+						className="toolbar-button color-button"
+						title={l10n.getString(color[0])}
+						onClick={() => handleColorPick(color[1])}
+					><IconColor16 color={color[1]}/></button>))}
+				</div>
+				<div className="tool-toggle" data-tabstop={1}>
+					<button
+						tabIndex={-1}
+						className={cx('highlight', { active: props.textSelectionAnnotationMode === 'highlight' })}
+						title={l10n.getString('reader-highlight-text')}
+						onClick={() => props.onChangeTextSelectionAnnotationMode('highlight')}
+					><IconHighlight/></button>
+					<button
+						tabIndex={-1}
+						className={cx('underline', { active: props.textSelectionAnnotationMode === 'underline' })}
+						title={l10n.getString('reader-underline-text')}
+						onClick={() => props.onChangeTextSelectionAnnotationMode('underline')}
+					><IconUnderline/></button>
+				</div>
 			</div>
 			{props.enableAddToNote &&
 				<button className="toolbar-button wide-button" data-tabstop={1} onClick={handleAddToNote}>

--- a/src/common/focus-manager.js
+++ b/src/common/focus-manager.js
@@ -81,7 +81,7 @@ export class FocusManager {
 
 	_handlePointerDown(event) {
 		if ('closest' in event.target) {
-			if (!event.target.closest('input, textarea, [contenteditable="true"], .annotation, .thumbnails-view, .outline-view, .error-bar, .reference-row, .preview-popup, .appearance-popup, #selector')) {
+			if (!event.target.closest('input, textarea, select, [contenteditable="true"], .annotation, .thumbnails-view, .outline-view, .error-bar, .reference-row, .preview-popup, .appearance-popup, #selector')) {
 				// Note: Doing event.preventDefault() also prevents :active class on Firefox
 				event.preventDefault();
 			}

--- a/src/common/stylesheets/components/_view-popup.scss
+++ b/src/common/stylesheets/components/_view-popup.scss
@@ -218,7 +218,7 @@
 	display: inline-flex;
 	align-items: center;
 	gap: 6px;
-	padding: 6px 10px;
+	padding: 6px 12px;  // Increased horizontal padding for even spacing around text and chevron
 }
 
 .selection-popup .deeptutor-translate-caret {
@@ -259,9 +259,39 @@
 
 .selection-popup .deeptutor-translate-controls {
 	display: grid;
-	grid-template-columns: 1fr 1fr;
-	gap: 12px;  // Increase gap for better spacing
+	grid-template-columns: 1fr auto 1fr;  // Source | Swap | Target
+	gap: 8px;  // Tighter gap for 3-column layout
 	width: 100%;  // Ensure full width for centering
+	align-items: end;  // Align swap button with dropdowns
+}
+
+// Swap button wrapper - aligns with select elements (below labels)
+.selection-popup .deeptutor-translate-swap {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	padding-top: 22px;  // Offset to align with selects (below labels)
+}
+
+.selection-popup .deeptutor-swap-btn {
+	background: transparent;
+	border: none;
+	color: var(--fill-secondary);
+	font-size: 16px;
+	cursor: pointer;
+	padding: 6px 8px;
+	border-radius: 4px;
+	transition: background 0.15s ease, color 0.15s ease;
+
+	&:hover:not(:disabled) {
+		background: var(--fill-quinary);
+		color: var(--fill-primary);
+	}
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
 }
 
 .selection-popup .deeptutor-translate-label {
@@ -284,7 +314,14 @@
 	display: flex;
 	gap: 8px;
 	margin-top: 8px;
-	justify-content: flex-end;  // Right-align buttons
+	justify-content: space-between;  // Clear left, Copy+Translate right
+	align-items: center;
+}
+
+// Right-side button group (Copy + Translate)
+.selection-popup .deeptutor-translate-actions-right {
+	display: flex;
+	gap: 8px;
 }
 
 .selection-popup .deeptutor-translate-actions button {

--- a/src/common/stylesheets/components/_view-popup.scss
+++ b/src/common/stylesheets/components/_view-popup.scss
@@ -250,7 +250,7 @@
 .selection-popup .deeptutor-translate-header button {
 	white-space: nowrap;
 	overflow: visible;  // Don't clip text
-	margin-left: 0;  // Ensure button doesn't shift left
+	margin-left: -8px;  // Pull left so T aligns with "Translate from" label below
 	flex-shrink: 0;  // Prevent button from shrinking and clipping text
 	width: auto;  // Override toolbar-button's 28px width
 	height: auto;  // Override toolbar-button's 28px height
@@ -277,8 +277,8 @@
 	background: transparent;
 	border: none;
 	color: var(--fill-secondary);
-	font-size: 20px;  // Larger icon for visibility
-	font-weight: 600;  // Bolder appearance
+	font-size: 24px;  // Larger icon for visibility
+	font-weight: normal;  // Thinner appearance to match target design
 	cursor: pointer;
 	padding: 6px 8px;
 	border-radius: 4px;

--- a/src/common/stylesheets/components/_view-popup.scss
+++ b/src/common/stylesheets/components/_view-popup.scss
@@ -254,7 +254,7 @@
 	flex-shrink: 0;  // Prevent button from shrinking and clipping text
 	width: auto;  // Override toolbar-button's 28px width
 	height: auto;  // Override toolbar-button's 28px height
-	padding: 4px 8px 4px 0;  // Remove left padding to align with labels below
+	padding: 4px 8px;  // Symmetric padding for hover state breathing room
 }
 
 .selection-popup .deeptutor-translate-controls {
@@ -277,7 +277,8 @@
 	background: transparent;
 	border: none;
 	color: var(--fill-secondary);
-	font-size: 16px;
+	font-size: 20px;  // Larger icon for visibility
+	font-weight: 600;  // Bolder appearance
 	cursor: pointer;
 	padding: 6px 8px;
 	border-radius: 4px;
@@ -330,7 +331,8 @@
 	border-radius: 6px;
 	font-weight: 500;
 	height: auto;
-	min-width: 70px;  // Minimum clickable width
+	min-width: 85px;  // Increased to fit "Translating..." text
+	white-space: nowrap;  // Prevent text wrapping/overflow
 }
 
 // Clear button - white background, blue text

--- a/src/common/stylesheets/components/_view-popup.scss
+++ b/src/common/stylesheets/components/_view-popup.scss
@@ -303,6 +303,7 @@
 
 .selection-popup .deeptutor-translate-select {
 	width: 100%;
+	min-width: 120px;  // Prevent dimension changes on first dropdown interaction
 	padding: 8px;  // Increase padding
 	border-radius: 6px;
 	border: 1px solid var(--fill-quinary);


### PR DESCRIPTION
## Summary
- add translate selection controls (swap/copy) and UI polish
- allow native select dropdowns to open without focus manager interference
- prevent selection popup jump by repositioning on resize

## Testing
- Not run (not requested)